### PR TITLE
Change the title to 'Aleksei'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
                     format!(r#"
 <!DOCTYPE html>
 
-<title>Voronov</title>
+<title>Aleksei</title>
 
 <style type="text/css">
 


### PR DESCRIPTION
It is very important that the only text on voronov.nl is "Aleksei"

For future iterations I propose to use the constant TEXT for that
but for this fix I opted out of doing that for consistency with the
sister repository [1]

[1] https://github.com/despawnerer/aleksei.nl